### PR TITLE
Fix preview enum, cache date formatters

### DIFF
--- a/Views/ActivityViews/ActivityRow.swift
+++ b/Views/ActivityViews/ActivityRow.swift
@@ -20,7 +20,7 @@ struct ActivityRow: View {
         startTime: Date(),
         endTime: Date().addingTimeInterval(3600),
         location: Location(name: "Sample Location", latitude: 0, longitude: 0),
-        category: .sightseeing,
+        category: .places,
         notes: "Sample notes"
     )
     

--- a/Views/ActivityViews/ActivityRowView.swift
+++ b/Views/ActivityViews/ActivityRowView.swift
@@ -62,11 +62,15 @@ struct ActivityRowView: View {
         return "\(start) - \(end)"
     }
     
-    private var timeFormatter: DateFormatter {
+    private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.timeStyle = .short
         formatter.dateStyle = .none
         return formatter
+    }()
+
+    private var timeFormatter: DateFormatter {
+        Self.timeFormatter
     }
 }
 

--- a/Views/ActivityViews/ItineraryView.swift
+++ b/Views/ActivityViews/ItineraryView.swift
@@ -19,8 +19,7 @@ struct ItineraryView: View {
     @State private var lastActivitiesCount = 0
     
     var body: some View {
-        let _ = updateCacheIfNeeded()
-        return VStack(spacing: 0) {
+        VStack(spacing: 0) {
             // Trip Header
             VStack(alignment: .leading, spacing: 8) {
                 Text(trip.name)
@@ -80,6 +79,10 @@ struct ItineraryView: View {
             .padding(.bottom)
         }
         .background(Color(.systemGroupedBackground))
+        .onAppear(perform: updateCacheIfNeeded)
+        .onChange(of: trip.activities) { _ in
+            updateCacheIfNeeded()
+        }
     }
     
     /// Sorted activities, cached for performance

--- a/Views/TripViews/TripRowView.swift
+++ b/Views/TripViews/TripRowView.swift
@@ -27,9 +27,14 @@ struct TripRowView: View {
         .padding(.vertical, 4)
     }
     
-    private var dateRangeText: String {
+    private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    private var dateRangeText: String {
+        let formatter = Self.dateFormatter
         return "\(formatter.string(from: trip.startDate)) - \(formatter.string(from: trip.endDate))"
     }
 }


### PR DESCRIPTION
## Summary
- fix invalid enum reference in `ActivityRow` preview
- cache DateFormatters in `ActivityRowView` and `TripRowView`
- move itinerary cache refresh into `.onAppear`/`.onChange`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6849b3f320ac832590aac06cdc00d888