### PR TITLE
Fix Trip initializer and unify navigation

### DIFF
--- a/Managers/TripStore.swift
+++ b/Managers/TripStore.swift
@@ -18,10 +18,8 @@ import Observation
     private let context: ModelContext
 
     // MARK: – Init
-    init() {
-        // Create the model container on the MainActor
-        let container = try! ModelContainer(for: Trip.self, Activity.self)
-        self.context = ModelContext(container)
+    init(context: ModelContext) {
+        self.context = context
         loadTrips()
     }
 

--- a/Models/Trip.swift
+++ b/Models/Trip.swift
@@ -21,7 +21,7 @@ import SwiftData
          title: String = "",
          startDate: Date = .now,
          endDate: Date = .now,
-         cities: [String] = [],
+         cityName: String = "",
          activities: [Activity] = []) {
         self.id = id
         self.title = title

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Trip Planner
+
+A SwiftUI app for planning trips using SwiftData.
+
+## Requirements
+- Xcode 15 or later
+- iOS 17 SDK
+
+## Building
+Open `TripPlanner.xcodeproj` in Xcode and run the `TripPlannerApp` scheme.
+
+## Running Tests
+Use the Product \> Test menu in Xcode or run `xcodebuild test` on the command line.

--- a/TripPlannerTests/TripPlannerTests.swift
+++ b/TripPlannerTests/TripPlannerTests.swift
@@ -12,7 +12,9 @@ final class TripStoreTests: XCTestCase {
 
     @MainActor func testAddTripPersists() {
         // Arrange
-        let store = TripStore()          // uses in-memory container
+        let container = try! ModelContainer(for: Trip.self, Activity.self, inMemory: true)
+        let context = ModelContext(container)
+        let store = TripStore(context: context)
         let trip  = Trip()
         trip.title = "Test Trip"
 

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -8,16 +8,24 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var store = TripStore()
+    @Environment(\.modelContext) private var modelContext
+    @State private var store: TripStore?
     @State private var showingNewTrip = false     // ← NEW
 
     var body: some View {
-        NavigationView {
-            List(store.trips) { trip in
-                NavigationLink {
-                    TripDetailView(trip: trip)
-                } label: {
-                    Text(trip.title.isEmpty ? "Untitled Trip" : trip.title)
+        NavigationStack {
+            Group {
+                if let store = store {
+                    List(store.trips) { trip in
+                        NavigationLink {
+                            TripDetailView(trip: trip)
+                        } label: {
+                            Text(trip.title.isEmpty ? "Untitled Trip" : trip.title)
+                        }
+                    }
+                } else {
+                    ProgressView()
+                        .onAppear { store = TripStore(context: modelContext) }
                 }
             }
             .navigationTitle("Trips")
@@ -28,9 +36,11 @@ struct ContentView: View {
                     Label("Add Trip", systemImage: "plus")
                 }
             }
-            .sheet(isPresented: $showingNewTrip) {     // ← NEW
-                NewTripSheet { trip in
-                    store.addTrip(trip)
+            .sheet(isPresented: $showingNewTrip) {
+                if let store = store {
+                    NewTripSheet { trip in
+                        store.addTrip(trip)
+                    }
                 }
             }
         }
@@ -39,4 +49,5 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        .modelContainer(for: [Trip.self, Activity.self], inMemory: true)
 }

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -5,7 +5,9 @@
 //  Created by Matt Berman on 6/16/25.
 //
 
+
 import SwiftUI
+import SwiftData
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext

--- a/Views/TripDetailView.swift
+++ b/Views/TripDetailView.swift
@@ -15,7 +15,8 @@ import SwiftData
 /// The sidebar can’t be collapsed because the nav-toolbar is hidden.
 struct TripDetailView: View {
     let trip: Trip
-
+    @Environment(\.dismiss) private var dismiss
+    
     @State private var mapPosition = MapCameraPosition.region(
         MKCoordinateRegion(
             center: .init(latitude: 0, longitude: 0),
@@ -40,7 +41,6 @@ struct TripDetailView: View {
         }
         .navigationTitle(trip.title.isEmpty ? "Trip" : trip.title)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar(.hidden, for: .navigationBar)   // hide collapse button
         .onAppear(perform: setInitialRegion)
     }
 


### PR DESCRIPTION
## Summary
- fix Trip initializer to use `cityName` parameter
- use `NavigationStack` in ContentView and lazy init TripStore with environment ModelContext
- inject `ModelContext` into TripStore
- update unit test for injected context
- document how to build and test the project

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685386d708608325aab87f91fc93e64c